### PR TITLE
Add `ruleset.rules` accessor

### DIFF
--- a/codeowners-rs/src/ruleset.rs
+++ b/codeowners-rs/src/ruleset.rs
@@ -19,7 +19,7 @@ use crate::patternset;
 /// ```
 #[derive(Clone)]
 pub struct RuleSet {
-    rules: Vec<Rule>,
+    pub rules: Vec<Rule>,
     matcher: patternset::Matcher,
 }
 
@@ -129,4 +129,15 @@ pub enum OwnerKind {
     User,
     Team,
     Email,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rules_public() {
+        let ruleset = RuleSet::new(vec![]);
+        assert_eq!(ruleset.rules, vec![]);
+    }
 }

--- a/codeowners-rs/src/ruleset.rs
+++ b/codeowners-rs/src/ruleset.rs
@@ -19,7 +19,7 @@ use crate::patternset;
 /// ```
 #[derive(Clone)]
 pub struct RuleSet {
-    pub rules: Vec<Rule>,
+    rules: Vec<Rule>,
     matcher: patternset::Matcher,
 }
 
@@ -66,6 +66,10 @@ impl RuleSet {
             .iter()
             .map(|&idx| (idx, &self.rules[idx]))
             .collect()
+    }
+
+    pub fn rules(&self) -> &[Rule] {
+        &self.rules
     }
 }
 
@@ -136,8 +140,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_rules_public() {
+    fn test_rules_getter() {
         let ruleset = RuleSet::new(vec![]);
-        assert_eq!(ruleset.rules, vec![]);
+        assert_eq!(ruleset.rules(), &[]);
     }
 }


### PR DESCRIPTION
Hey @hmarr, really appreciate your work on this. I'm working on some Ruby bindings to this library, and this little tweak would be helpful to provide an accessor to the rules. I'm not experienced with Rust, so please advise if you think this should be done a different way, like via a getter.